### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "readme",
     "github"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akameco/readme-gen.git"
+  },
   "author": "akameco",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This adds a link to [the GitHub repository](https://github.com/akameco/readme-gen) from [the npmjs page](https://www.npmjs.com/package/readme-gen). You will need to publish to npm after making these changes for the link to appear.
